### PR TITLE
[ISSUE-1] Add native JS class analyser with very basic implementation

### DIFF
--- a/lib/analyzers/extends-syntax.js
+++ b/lib/analyzers/extends-syntax.js
@@ -104,8 +104,14 @@ class ExtendsSyntaxAnalyzer {
 
             if (parentClassImportTokens) {
               parentClassDefinitionPath = parentClassImportTokens[0];
+
+              break;
             }
           }
+        }
+
+        if (parentClassDefinitionPath.includes('models/')) {
+          parentClassDefinitionPath = path.parse(parentClassDefinitionPath).name;
         }
 
         const baseModelabsolutePath = path.join(modelDefinitionsDirectory, `${parentClassDefinitionPath}.js`);

--- a/lib/analyzers/native-js-class.js
+++ b/lib/analyzers/native-js-class.js
@@ -1,6 +1,12 @@
 const { camelize } = require('./../utils');
 const fs = require('fs');
 const path = require('path');
+const EMBER_DATA_AND_FRAGMENTS_BASE_CLASSES = Object.freeze([
+  'Model',
+  'DS.Model',
+  'MF.Fragment',
+  'Fragment'
+]);
 
 class NativeJsClassAnalyzer {
   parseSourceCode(modelSourceCode, modelDefinitionsDirectory) {
@@ -26,11 +32,13 @@ class NativeJsClassAnalyzer {
     let baseModelName;
 
     lines.forEach((line, index) => {
-      if (/\.extend /.test(line) && checkExtendedClass) {
-        const classExtendTokens = line.match(/(?<=default )(.*?)(?=\.extend\()/);
+      const NATIVE_CLASS_SYNTAX_KEYWORD_PATTERN = /class[\s]+(.*)[\s]+(extends{1})[\s]+(.*)[{]{1}/;
+
+      if (NATIVE_CLASS_SYNTAX_KEYWORD_PATTERN.test(line) && checkExtendedClass) {
+        const classExtendTokens = line.match(/(?<=extends)(.*?)(?=\{)/);
 
         if (classExtendTokens) {
-          baseModelName = classExtendTokens[0]
+          baseModelName = classExtendTokens[0].trim()
 
           modelData.type = baseModelName;
         }

--- a/lib/analyzers/native-js-class.js
+++ b/lib/analyzers/native-js-class.js
@@ -2,31 +2,7 @@ const { camelize } = require('./../utils');
 const fs = require('fs');
 const path = require('path');
 
-const EMBER_DATA_AND_FRAGMENTS_BASE_CLASSES = Object.freeze([
-  'Model',
-  'DS.Model',
-  'MF.Fragment',
-  'Fragment'
-]);
-
-/**
- * @description Analize the source code of a file to extract the information
- * required to render the diagram. This Analyzer understands the following
- * syntaxt to define Ember models:
-
-  export default Model.extend({
-    firstName: attr(),
-    lastName: attr(),
-  }
-
-  export default DS.Model.extend({
-    firstName: attr(),
-    lastName: attr(),
-  }
-
-  It does support Model fragments as well.
-*/
-class ExtendsSyntaxAnalyzer {
+class NativeJsClassAnalyzer {
   parseSourceCode(modelSourceCode, modelDefinitionsDirectory) {
     const lines = modelSourceCode.split(/\r?\n/);
     const modelData = {
@@ -37,6 +13,7 @@ class ExtendsSyntaxAnalyzer {
         belongsTo: []
       }
     };
+
     this._readModelDataFromCodeLines(lines, modelData, modelDefinitionsDirectory);
 
     return modelData;
@@ -48,8 +25,8 @@ class ExtendsSyntaxAnalyzer {
 
     let baseModelName;
 
-    lines.forEach(line => {
-      if (/\.extend\(/.test(line) && checkExtendedClass) {
+    lines.forEach((line, index) => {
+      if (/\.extend /.test(line) && checkExtendedClass) {
         const classExtendTokens = line.match(/(?<=default )(.*?)(?=\.extend\()/);
 
         if (classExtendTokens) {
@@ -63,34 +40,56 @@ class ExtendsSyntaxAnalyzer {
         importLines.push(line);
       }
 
-      if (/attr/.test(line) && /:/.test(line)) {
-        const attributeName = line.split(':')[0].trim();
+      if (/@attr/.test(line)) {
+        let attributeName = line.trim().match(/(@attr(.*)|@attr)\s(.*);/)[3]
+
+        if (!attributeName) {
+          attributeName = lines[index+1].trim();
+        }
 
         modelData.attributes.push(attributeName);
       }
 
-      if ((/fragmentArray/.test(line) || /hasMany/.test(line)) && /:/.test(line)) {
-        let relationshipName = line.split(':')[0].trim();
+      if (/@hasMany/.test(line) || /@fragmentArray/.test(line)) {
+        const relationshipDefinitionTokens = line.trim().match(modelNameRexp);
 
-        const modelName = line.split(':')[1].match(modelNameRexp);
+        let relationshipName;
 
-        if (modelName) {
-          relationshipName = modelName[0];
+        if (relationshipDefinitionTokens) {
+          relationshipName = relationshipDefinitionTokens[0];
+        } else {
+          relationshipName = line.trim().split(' ')[1];
         }
 
-        modelData.relationships.hasMany.push(camelize(relationshipName));
+        if (!relationshipName) {
+          relationshipName = lines[index+1].trim();
+        }
+
+        if (relationshipName) {
+          relationshipName = relationshipName.replace(';','');
+          modelData.relationships.hasMany.push(camelize(relationshipName));
+        }
       }
 
-      if ((/fragment/.test(line) || /belongsTo/.test(line)) && /:/.test(line)) {
-        let relationshipName = line.split(':')[0].trim();
+      if (/@belongsTo/.test(line) || /@fragment/.test(line)) {
+        const relationshipDefinitionTokens = line.trim().match(modelNameRexp);
 
-        const modelName = line.split(':')[1].match(modelNameRexp);
+        let relationshipName;
 
-        if (modelName) {
-          relationshipName = modelName[0];
+        if (relationshipDefinitionTokens) {
+          relationshipName = relationshipDefinitionTokens[0];
+        } else {
+          relationshipName = line.trim().split(' ')[1];
         }
 
-        modelData.relationships.belongsTo.push(camelize(relationshipName));
+        if (!relationshipName) {
+          relationshipName = lines[index+1].trim();
+        }
+
+        if (relationshipName) {
+          relationshipName = relationshipName.replace(';','');
+          modelData.relationships.belongsTo.push(camelize(relationshipName));
+        }
       }
     });
 
@@ -125,4 +124,4 @@ class ExtendsSyntaxAnalyzer {
   }
 }
 
-module.exports = ExtendsSyntaxAnalyzer;
+module.exports = NativeJsClassAnalyzer;

--- a/lib/analyzers/native-js-class.js
+++ b/lib/analyzers/native-js-class.js
@@ -111,8 +111,14 @@ class NativeJsClassAnalyzer {
 
             if (parentClassImportTokens) {
               parentClassDefinitionPath = parentClassImportTokens[0];
+
+              break;
             }
           }
+        }
+
+        if (parentClassDefinitionPath.includes('models/')) {
+          parentClassDefinitionPath = path.parse(parentClassDefinitionPath).name;
         }
 
         const baseModelabsolutePath = path.join(modelDefinitionsDirectory, `${parentClassDefinitionPath}.js`);

--- a/lib/constants/graph.js
+++ b/lib/constants/graph.js
@@ -23,8 +23,7 @@ const DEFAULT_GRAPH_OPTIONS = Object.freeze({
   orientation: 'TB',
   overlap: false,
   esep: '10',
-  concentrate: true,
-  comment: 'ENTITY RELATIONSHIP DIAGRAM'
+  concentrate: false
 });
 
 module.exports = {

--- a/lib/generators/erd-generator.js
+++ b/lib/generators/erd-generator.js
@@ -133,7 +133,7 @@ class ErdGenerator {
         if (relatedModelNode) {
           const relatedModelHasManyRelationships = models[relatedModelName].relationships.hasMany;
           const isBidirectional = !!relatedModelHasManyRelationships.find((relationship) => {
-            return relationship === modelName
+            return relationship === modelName || inflection.singularize(modelName)
           });
 
           if (isBidirectional) {
@@ -144,7 +144,11 @@ class ErdGenerator {
 
 
             if (relationshipEdge) {
-              relationshipEdge.set('dir', 'both');
+              // Direction both doesn't seem to be supported
+              // https://graphviz.org/doc/info/attrs.html#k:dirType
+              relationshipEdge.set('dir', 'none');
+              relationshipEdge.set('headlabel', '*');
+              relationshipEdge.set('taillabel', '*');
 
               continue;
             }
@@ -157,7 +161,11 @@ class ErdGenerator {
           this._applyOptions(relationship, DEFAULT_HAS_MANY_GRAPH_TO_OPTIONS);
 
           if (isBidirectional) {
-            relationship.set('dir', 'both');
+            // Direction both doesn't seem to be supported
+            // https://graphviz.org/doc/info/attrs.html#k:dirType
+            relationship.set('dir', 'none');
+            relationship.set('headlabel', '*');
+            relationship.set('taillabel', '*');
           }
         } else {
           console.log(`Missing model ${modelName} has many ${relatedModelNode}`);
@@ -181,7 +189,11 @@ class ErdGenerator {
 
 
           if (relationshipEdge) {
-            relationshipEdge.set('dir', 'both');
+            // Direction both doesn't seem to be supported
+            // https://graphviz.org/doc/info/attrs.html#k:dirType
+            relationshipEdge.set('dir', 'none');
+            relationshipEdge.set('headlabel', '1');
+            relationshipEdge.set('taillabel', '1');
 
             continue;
           }
@@ -197,7 +209,11 @@ class ErdGenerator {
           this._applyOptions(relationship, DEFAULT_BELONGS_TO_GRAPH_OPTIONS);
 
           if (isBidirectional) {
-            relationship.set('dir', 'both');
+              // Direction both doesn't seem to be supported
+              // https://graphviz.org/doc/info/attrs.html#k:dirType
+              relationship.set('dir', 'none');
+              relationship.set('headlabel', '*');
+              relationship.set('taillabel', '*');
           }
         } else {
           console.log(`Missing  model:  ${modelName} belongs to ${relatedModelNode}`);

--- a/lib/generators/erd-generator.js
+++ b/lib/generators/erd-generator.js
@@ -4,6 +4,7 @@ const inflection = require('inflection');
 const graphviz = require('graphviz');
 const { camelize } = require('../utils');
 const ExtendsSyntaxAnalyzer = require('../analyzers/extends-syntax');
+const NativeJsClassAnalyzer = require('../analyzers/native-js-class');
 const {
   DEFAULT_HAS_MANY_GRAPH_TO_OPTIONS,
   DEFAULT_BELONGS_TO_GRAPH_OPTIONS,
@@ -34,7 +35,6 @@ class ErdGenerator {
     const modelDefinitionsDirectory = path.join(mainDirectory, directory);
     const modelFileDefinitions = fs.readdirSync(modelDefinitionsDirectory);
     const models = {};
-    const analyzer = new ExtendsSyntaxAnalyzer();
 
     for (let i = 0; i < modelFileDefinitions.length; i++) {
       if (/\.js/.test(modelFileDefinitions[i])) {
@@ -49,6 +49,7 @@ class ErdGenerator {
         try {
           const filePath = path.join(mainDirectory, file);
           const modelSourceCode = fs.readFileSync(filePath, 'UTF-8');
+          const analyzer = this._getModelAnalyzer(modelSourceCode)
 
           models[modelName] = analyzer.parseSourceCode(modelSourceCode, modelDefinitionsDirectory);
         } catch (err) {
@@ -63,8 +64,10 @@ class ErdGenerator {
 
   createGraph() {
     const graph = graphviz.digraph('G');
+    const defaultOptions = Object.assign({}, DEFAULT_GRAPH_OPTIONS);
+    const graphOptions = Object.assign(defaultOptions, this.options.graphviz);
 
-    this._applyOptions(graph, DEFAULT_GRAPH_OPTIONS);
+    this._applyOptions(graph, graphOptions);
     this._addNodes(graph);
     this._addEdges(graph);
 
@@ -94,6 +97,15 @@ class ErdGenerator {
       console.log(`🔴  There was an error rendering the diagram`);
       console.log(code, out, err);
     });
+  }
+
+  _getModelAnalyzer(modelSourceCode) {
+    const NATIVE_CLASS_SYNTAX_KEYWORD_PATTERN = /class[\s]+(.*)[\s]+(extends{1})[\s]+(.*)[{]{1}/;
+
+    if (modelSourceCode.match(NATIVE_CLASS_SYNTAX_KEYWORD_PATTERN)) {
+      return new NativeJsClassAnalyzer();
+    }
+    return new ExtendsSyntaxAnalyzer();
   }
 
   _addEdges(graph) {


### PR DESCRIPTION
## Description

- Add naive support for Native JS classes + decorators.
- Stop using dir = both, it is not working. Use dir none instead.
- Allow setting value for `concentrate`.
- Add break after finding base class import.


This is a first attempt to address: https://github.com/dmuneras/ember-data-erd/issues/1

## Pending

- Clean up code and remove duplication of code in the graph render functions.